### PR TITLE
Remove unneeded items from ExampleCommand

### DIFF
--- a/src/main/java/frc/robot/commands/ExampleCommand.java
+++ b/src/main/java/frc/robot/commands/ExampleCommand.java
@@ -15,7 +15,7 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
  */
 public class ExampleCommand extends CommandBase {
   @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
-  private final ExampleSubsystem m_subsystem;
+  //private final ExampleSubsystem m_subsystem;
 
   /**
    * Creates a new ExampleCommand.
@@ -23,7 +23,7 @@ public class ExampleCommand extends CommandBase {
    * @param subsystem The subsystem used by this command.
    */
   public ExampleCommand(ExampleSubsystem subsystem) {
-    m_subsystem = subsystem;
+    //m_subsystem = subsystem;
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(subsystem);
   }


### PR DESCRIPTION
I think this is very functional, makes our code easier to read, and should like, totes be put into the robot. thx <3 <3 <3	

I commented out two unnecessary variables, that were not in use.

Co-Authored-By: CocoCR <42189336+cocothebam@users.noreply.github.com>
Co-Authored-By: L02s <74326169+l02s@users.noreply.github.com>
Co-Authored-By: TheK1llerbear <52019110+TheK1llerBear@users.noreply.github.com>
Co-Authored-By: KhanSimeoni <54782076+KhanSimeoni@users.noreply.github.com>